### PR TITLE
Handle chat disconnects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pro.beam</groupId>
     <artifactId>api</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/src/example/java/pro/beam/api/example/Application.java
+++ b/src/example/java/pro/beam/api/example/Application.java
@@ -1,0 +1,31 @@
+package pro.beam.api.example;
+
+import pro.beam.api.BeamAPI;
+import pro.beam.api.resource.BeamUser;
+import pro.beam.api.resource.chat.BeamChat;
+import pro.beam.api.resource.chat.BeamChatBridge;
+import pro.beam.api.resource.chat.events.EventHandler;
+import pro.beam.api.resource.chat.events.IncomingMessageEvent;
+import pro.beam.api.resource.chat.methods.AuthenticateMessage;
+import pro.beam.api.services.impl.ChatService;
+import pro.beam.api.services.impl.UsersService;
+
+import java.util.concurrent.ExecutionException;
+
+public class Application {
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
+        BeamAPI beam = new BeamAPI();
+
+        BeamUser user = beam.use(UsersService.class).login("<username>", "<password>").get();
+        BeamChat chat = beam.use(ChatService.class).findOne(user.channel.id).get();
+
+        BeamChatBridge bridge = chat.bridge(beam).connect();
+        bridge.send(AuthenticateMessage.from(user.channel, user, chat.authkey));
+
+        bridge.on(IncomingMessageEvent.class, new EventHandler<IncomingMessageEvent>() {
+            @Override public void onEvent(IncomingMessageEvent event) {
+                System.out.println(event.data.getMessage());
+            }
+        });
+    }
+}

--- a/src/example/java/pro/beam/api/example/Application.java
+++ b/src/example/java/pro/beam/api/example/Application.java
@@ -12,16 +12,33 @@ import pro.beam.api.services.impl.UsersService;
 
 import java.util.concurrent.ExecutionException;
 
+/**
+ * This class serves as a demo to show off basic functionality of the Beam Java Client.
+ * The following snippet of code connects to a user's own channel (provided a username
+ * and password), and then outputs all messages to stdout via an EventHandler.
+ *
+ * The source is annotated:
+ */
 public class Application {
     public static void main(String[] args) throws ExecutionException, InterruptedException {
+        // Construct an instance of the Beam API. This holds all of the services that are
+        // used to make various requests and do certain things.
         BeamAPI beam = new BeamAPI();
 
+        // Construct a "user" object that represents the user corresponding to the <username>
+        // and <password> provided below.
         BeamUser user = beam.use(UsersService.class).login("<username>", "<password>").get();
+        // Fetch the chat object that belongs to the user's channel.
         BeamChat chat = beam.use(ChatService.class).findOne(user.channel.id).get();
 
+        // Construct a bridge to make that chat interactive, and then connect to it.
         BeamChatBridge bridge = chat.bridge(beam).connect();
+        // Once the bridge is constructed, send the authentication packet to verify that
+        // we are who we say we are, and that we have the rights to chat.
         bridge.send(AuthenticateMessage.from(user.channel, user, chat.authkey));
 
+        // Finally, attach an EventHandler to the IncomingMessageEvent class such that
+        // when the event is sent down, the message is printed to stdout.
         bridge.on(IncomingMessageEvent.class, new EventHandler<IncomingMessageEvent>() {
             @Override public void onEvent(IncomingMessageEvent event) {
                 System.out.println(event.data.getMessage());

--- a/src/main/java/pro/beam/api/resource/chat/BeamChat.java
+++ b/src/main/java/pro/beam/api/resource/chat/BeamChat.java
@@ -1,14 +1,11 @@
 package pro.beam.api.resource.chat;
 
 import pro.beam.api.BeamAPI;
-import pro.beam.api.http.ws.ConnectionProducer;
 
-import javax.net.ssl.SSLSocketFactory;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Random;
 
-public class BeamChat implements ConnectionProducer<BeamChatConnectable> {
+public class BeamChat {
     public String authkey;
     public String[] endpoints;
     public boolean linksAllowed;
@@ -16,18 +13,8 @@ public class BeamChat implements ConnectionProducer<BeamChatConnectable> {
     public String role;
     public double slowchat;
 
-    @Override
-    public BeamChatConnectable makeConnectable(BeamAPI beam) {
-        BeamChatConnectable connectable = new BeamChatConnectable(beam, this.selectEndpoint(), this);
-
-        SSLSocketFactory sf = (SSLSocketFactory) SSLSocketFactory.getDefault();
-        try {
-            connectable.setSocket(sf.createSocket());
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        return connectable;
+    public BeamChatBridge bridge(BeamAPI beam) {
+        return new BeamChatBridge(beam, this);
     }
 
     public URI selectEndpoint() {

--- a/src/main/java/pro/beam/api/resource/chat/BeamChatBridge.java
+++ b/src/main/java/pro/beam/api/resource/chat/BeamChatBridge.java
@@ -1,0 +1,94 @@
+package pro.beam.api.resource.chat;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import pro.beam.api.BeamAPI;
+import pro.beam.api.resource.chat.events.EventHandler;
+import pro.beam.api.resource.chat.events.data.IncomingMessageData;
+import pro.beam.api.resource.chat.methods.AuthenticateMessage;
+import pro.beam.api.resource.chat.replies.ReplyHandler;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.util.Map;
+
+public class BeamChatBridge {
+    private static final SSLSocketFactory SSL_SOCKET_FACTORY = (SSLSocketFactory) SSLSocketFactory.getDefault();
+
+    protected final BeamAPI beam;
+    protected final BeamChat chat;
+
+    public BeamChatConnectable connectable;
+
+    protected AuthenticateMessage authenticate;
+    protected Multimap<Class<? extends AbstractChatEvent>, EventHandler> eventHandlers = HashMultimap.create();
+
+    public BeamChatBridge(BeamAPI beam, BeamChat chat) {
+        this.beam = beam;
+        this.chat = chat;
+    }
+
+    public BeamChatBridge connect() {
+        BeamChatConnectable newConnectable = new BeamChatConnectable(this, this.chat.selectEndpoint());
+
+        // Re-attach event handlers to the new connectable object.
+        for (Map.Entry<Class<? extends AbstractChatEvent>, EventHandler> entry : this.eventHandlers.entries()) {
+            newConnectable.on(entry.getKey(), entry.getValue());
+        }
+
+        try {
+            newConnectable.setSocket(SSL_SOCKET_FACTORY.createSocket());
+
+            newConnectable.connectBlocking();
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        this.connectable = newConnectable;
+
+        return this;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /////                       Delegate Methods Below                        /////
+    ///////////////////////////////////////////////////////////////////////////////
+    public <T extends AbstractChatEvent> boolean on(Class<T> eventType, EventHandler<T> handler) {
+        return this.connectable.on(eventType, handler);
+    }
+
+    public void send(AbstractChatMethod method) {
+        this.send(method, null);
+    }
+
+    public <T extends AbstractChatReply> void send(AbstractChatMethod method, ReplyHandler<T> handler) {
+        if (method.getClass() == AuthenticateMessage.class) {
+            this.authenticate = (AuthenticateMessage) method;
+        }
+
+        this.connectable.send(method, handler);
+    }
+
+    public void delete(IncomingMessageData message) {
+        this.connectable.delete(message);
+    }
+
+    protected void notifyClose(int i, String s, boolean b) {
+        try {
+            // HACK: Wait for 500ms because the WSS client doesn't correctly report it's state on
+            // whether or not it's closed, so we make sure that it is before opening a new connection.
+            Thread.sleep(500);
+        } catch (InterruptedException ignored) { }
+
+        // Cache the event-handlers.
+        this.eventHandlers = HashMultimap.create(this.connect().eventHandlers);
+
+        this.connect();
+        if (this.authenticate != null) {
+            this.send(this.authenticate);
+        }
+    }
+
+    public void disconnect() {
+        this.connectable.closeConnection(1000, "BEAM_JAVA_DISCONNECT");
+    }
+}

--- a/src/main/java/pro/beam/api/resource/chat/BeamChatConnectable.java
+++ b/src/main/java/pro/beam/api/resource/chat/BeamChatConnectable.java
@@ -71,7 +71,7 @@ public class BeamChatConnectable extends WebSocketClient {
         ReplyPair replyPair = null;
         try {
             // Parse out the generic JsonObject so we can pull out the ID element from it,
-            //  since we cannot yet parse as a generic class.
+            // since we cannot yet parse as a generic class.
             JsonObject e = this.bridge.beam.gson.fromJson(s, JsonObject.class);
             if (e.has("id")) {
                 this.dispatch.accept(e.get("id").getAsInt(), e);
@@ -81,10 +81,10 @@ public class BeamChatConnectable extends WebSocketClient {
                     Class<? extends AbstractChatEvent> type = AbstractChatEvent.EventType.fromSerializedName("WidgetMessage").getCorrespondingClass();
                     this.dispatch.accept(this.bridge.beam.gson.fromJson(e, type));
                 } else {
-                   // Use the default ChatMessage event handling
-                   String eventName = e.get("event").getAsString();
-                   Class<? extends AbstractChatEvent> type = AbstractChatEvent.EventType.fromSerializedName(eventName).getCorrespondingClass();
-                   this.dispatch.accept(this.bridge.beam.gson.fromJson(e, type));
+                    // Use the default ChatMessage event handling
+                    String eventName = e.get("event").getAsString();
+                    Class<? extends AbstractChatEvent> type = AbstractChatEvent.EventType.fromSerializedName(eventName).getCorrespondingClass();
+                    this.dispatch.accept(this.bridge.beam.gson.fromJson(e, type));
                 }
             }
         } catch (JsonSyntaxException e) {

--- a/src/main/java/pro/beam/api/resource/chat/BeamChatConnectable.java
+++ b/src/main/java/pro/beam/api/resource/chat/BeamChatConnectable.java
@@ -33,7 +33,8 @@ public class BeamChatConnectable extends WebSocketClient {
     }
 
     public <T extends AbstractChatEvent> boolean on(Class<T> eventType, EventHandler<T> handler) {
-        return this.dispatch.eventHandlers.put(eventType, handler);
+        this.dispatch.attachEventHandler(eventType, handler);
+        return true;
     }
 
     public void send(AbstractChatMethod method) {
@@ -42,7 +43,7 @@ public class BeamChatConnectable extends WebSocketClient {
 
     public <T extends AbstractChatReply> void send(final AbstractChatMethod method, ReplyHandler<T> handler) {
         if (handler != null) {
-            this.dispatch.replyHandlers.put(method.id, ReplyPair.from(handler));
+            this.dispatch.attachReplyHandler(method.id, ReplyPair.from(handler));
         }
 
         this.bridge.beam.executor.submit(new Callable<Object>() {

--- a/src/main/java/pro/beam/api/resource/chat/BeamChatConnectable.java
+++ b/src/main/java/pro/beam/api/resource/chat/BeamChatConnectable.java
@@ -13,7 +13,6 @@ import java.net.URI;
 
 import pro.beam.api.resource.chat.events.EventHandler;
 import pro.beam.api.resource.chat.events.data.IncomingMessageData;
-import pro.beam.api.resource.chat.events.data.IncomingWidgetData;
 import pro.beam.api.resource.chat.replies.ReplyHandler;
 
 import java.lang.reflect.ParameterizedType;
@@ -24,17 +23,15 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("unchecked")
 public class BeamChatConnectable extends WebSocketClient {
-    protected final BeamAPI beam;
-    protected final BeamChat chat;
+    protected final BeamChatBridge bridge;
 
     protected final Map<Integer, ReplyPair> replyHandlers;
     protected final Multimap<Class<? extends AbstractChatEvent>, EventHandler> eventHandlers;
 
-    public BeamChatConnectable(BeamAPI beam, URI endpoint, BeamChat chat) {
-        super(endpoint, new CookieDraft_17(beam.http));
+    public BeamChatConnectable(BeamChatBridge bridge, URI endpoint) {
+        super(endpoint, new CookieDraft_17(bridge.beam.http));
 
-        this.beam = beam;
-        this.chat = chat;
+        this.bridge = bridge;
 
         this.replyHandlers = new ConcurrentHashMap<>(new HashMap<Integer, ReplyPair>());
         this.eventHandlers = HashMultimap.create();
@@ -53,10 +50,10 @@ public class BeamChatConnectable extends WebSocketClient {
             this.replyHandlers.put(method.id, ReplyPair.from(handler));
         }
 
-        this.beam.executor.submit(new Callable<Object>() {
+        this.bridge.beam.executor.submit(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
-                byte[] data = BeamChatConnectable.this.beam.gson.toJson(method).getBytes();
+                byte[] data = BeamChatConnectable.this.bridge.beam.gson.toJson(method).getBytes();
                 BeamChatConnectable.this.send(data);
 
                 return null;
@@ -66,7 +63,7 @@ public class BeamChatConnectable extends WebSocketClient {
 
     public void delete(IncomingMessageData message) {
         String path = BeamAPI.BASE_PATH.resolve("chats/" + message.channel + "/message/" + message.id).toString();
-        this.beam.http.delete(path, null);
+        this.bridge.beam.http.delete(path, null);
     }
 
     private <T extends AbstractChatEvent> void dispatchEvent(T event) {
@@ -87,7 +84,7 @@ public class BeamChatConnectable extends WebSocketClient {
         try {
             // Parse out the generic JsonObject so we can pull out the ID element from it,
             //  since we cannot yet parse as a generic class.
-            JsonObject e = this.beam.gson.fromJson(s, JsonObject.class);
+            JsonObject e = this.bridge.beam.gson.fromJson(s, JsonObject.class);
             if (e.has("id")) {
                 int id = e.get("id").getAsInt();
 
@@ -98,19 +95,19 @@ public class BeamChatConnectable extends WebSocketClient {
 
                     // Now that we have the type, we can appropriately parse out the value
                     // And call the #onSuccess method with the value.
-                    AbstractChatDatagram datagram = this.beam.gson.fromJson(s, type);
+                    AbstractChatDatagram datagram = this.bridge.beam.gson.fromJson(s, type);
                     replyPair.handler.onSuccess(type.cast(datagram));
                 }
             } else if (e.has("event")) {
-                //handles cases of beam widgets (GiveawayBot) sending ChatMessage events
+                // Handles cases of Beam Widget (ex. GiveawayBot) sending ChatMessage events
                 if(e.getAsJsonObject("data").has("user_id") && e.getAsJsonObject("data").get("user_id").getAsInt() == -1) {
                         Class<? extends AbstractChatEvent> type = AbstractChatEvent.EventType.fromSerializedName("WidgetMessage").getCorrespondingClass();
-                        this.dispatchEvent(this.beam.gson.fromJson(e, type));
+                        this.dispatchEvent(this.bridge.beam.gson.fromJson(e, type));
                 } else {
-                    //default ChatMessage event handling
+                   // Use the default ChatMessage event handling
                    String eventName = e.get("event").getAsString();
                    Class<? extends AbstractChatEvent> type = AbstractChatEvent.EventType.fromSerializedName(eventName).getCorrespondingClass();
-                   this.dispatchEvent(this.beam.gson.fromJson(e, type));
+                   this.dispatchEvent(this.bridge.beam.gson.fromJson(e, type));
                 }
             }
         } catch (JsonSyntaxException e) {
@@ -126,19 +123,15 @@ public class BeamChatConnectable extends WebSocketClient {
 
     @Override
     public void onClose(int i, String s, boolean b) {
-        while (this.isClosed() && !this.isConnecting()) {
-            try {
-                this.uri = this.chat.selectEndpoint();
-                this.connectBlocking();
-            } catch (InterruptedException ignored) { }
-        }
+        this.bridge.notifyClose(i, s, b);
     }
 
     @Override
     public void onError(Exception e) {
+        e.printStackTrace();
     }
 
-    private static class ReplyPair<T extends AbstractChatReply> {
+    protected static class ReplyPair<T extends AbstractChatReply> {
         public ReplyHandler<T> handler;
         public Class<T> type;
 

--- a/src/main/java/pro/beam/api/resource/chat/ChatHandlerDispatch.java
+++ b/src/main/java/pro/beam/api/resource/chat/ChatHandlerDispatch.java
@@ -54,17 +54,22 @@ public class ChatHandlerDispatch {
                     return true;
                 } else return false;
             }
-        })).run();
+        })).start();
     }
 
     public <T extends AbstractChatEvent> void attachEventHandler(final Class<T> eventType, final EventHandler<T> handler) {
         new Thread(new QueueWorker<>(this.eventQueue, new Function<AbstractChatEvent, Boolean>() {
             @Override public Boolean apply(AbstractChatEvent event) {
-                if (event.getClass() == eventType) {
-                    handler.onEvent((T) event);
-                    return true;
-                } else return false;
+                try {
+                    if (event.getClass() == eventType) {
+                        handler.onEvent((T) event);
+                        return true;
+                    } else return false;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return false;
+                }
             }
-        })).run();
+        })).start();
     }
 }

--- a/src/main/java/pro/beam/api/resource/chat/ChatHandlerDispatch.java
+++ b/src/main/java/pro/beam/api/resource/chat/ChatHandlerDispatch.java
@@ -1,0 +1,70 @@
+package pro.beam.api.resource.chat;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Queues;
+import com.google.gson.JsonObject;
+import pro.beam.api.BeamAPI;
+import pro.beam.api.resource.chat.events.EventHandler;
+import pro.beam.api.util.QueueWorker;
+
+import java.util.Map;
+import java.util.Queue;
+import java.util.function.Function;
+
+public class ChatHandlerDispatch {
+    protected final BeamAPI beam;
+
+    protected final Map<Integer, BeamChatConnectable.ReplyPair> replyHandlers;
+    protected final Multimap<Class<? extends AbstractChatEvent>, EventHandler> eventHandlers;
+
+    protected final Queue<AbstractChatReply> replyQueue = Queues.newArrayDeque();
+    protected final Queue<AbstractChatEvent> eventQueue = Queues.newArrayDeque();
+
+    public ChatHandlerDispatch(BeamAPI beam,
+                               final Map<Integer, BeamChatConnectable.ReplyPair> replyHandlers,
+                               final Multimap<Class<? extends AbstractChatEvent>, EventHandler> eventHandlers) {
+        this.beam = beam;
+
+        this.replyHandlers = replyHandlers;
+        this.eventHandlers = eventHandlers;
+
+        this.startWorkers();
+    }
+
+    public <T extends AbstractChatReply> void accept(int id, JsonObject o) {
+        BeamChatConnectable.ReplyPair pair = this.replyHandlers.get(id);
+        if (pair != null) {
+            Class<? extends AbstractChatDatagram> type = pair.type;
+            AbstractChatDatagram reply = this.beam.gson.fromJson(o.toString(), type);
+
+            this.replyQueue.offer((AbstractChatReply) reply);
+        }
+    }
+
+    public <T extends AbstractChatEvent> void accept(T event) {
+        this.eventQueue.offer(event);
+    }
+
+    private void startWorkers() {
+        new Thread(new QueueWorker<>(this.replyQueue, new Function<AbstractChatReply, Boolean>() {
+            @Override public Boolean apply(AbstractChatReply reply) {
+                BeamChatConnectable.ReplyPair replyPair = replyHandlers.remove(reply.id);
+                if (replyPair != null) {
+                    replyPair.handler.onSuccess(reply);
+                }
+
+                return true;
+            }
+        })).run();
+
+        new Thread(new QueueWorker<>(this.eventQueue, new Function<AbstractChatEvent, Boolean>() {
+            @Override public Boolean apply(AbstractChatEvent event) {
+                for (EventHandler handler : eventHandlers.get(event.getClass())) {
+                    handler.onEvent(event);
+                }
+
+                return true;
+            }
+        })).run();
+    }
+}

--- a/src/main/java/pro/beam/api/util/AbstractQueueWorker.java
+++ b/src/main/java/pro/beam/api/util/AbstractQueueWorker.java
@@ -15,7 +15,7 @@ public abstract class AbstractQueueWorker<T> implements Runnable {
     @Override public void run() {
         T next;
         while (this.shouldWork()) {
-            if ((next = this.queue.element()) != null) {
+            if ((next = this.queue.peek()) != null) {
                 boolean shouldRemove = this.applicant.apply(next);
                 if (shouldRemove) {
                     this.notifyWorkOn(next);

--- a/src/main/java/pro/beam/api/util/AbstractQueueWorker.java
+++ b/src/main/java/pro/beam/api/util/AbstractQueueWorker.java
@@ -13,14 +13,18 @@ public abstract class AbstractQueueWorker<T> implements Runnable {
     }
 
     @Override public void run() {
-        T next;
         while (this.shouldWork()) {
-            if ((next = this.queue.peek()) != null) {
+            while (this.queue.isEmpty());
+
+            try {
+                T next = this.queue.peek();
                 boolean shouldRemove = this.applicant.apply(next);
                 if (shouldRemove) {
                     this.notifyWorkOn(next);
                     this.queue.remove(next);
                 }
+            } catch (Exception e) {
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/pro/beam/api/util/AbstractQueueWorker.java
+++ b/src/main/java/pro/beam/api/util/AbstractQueueWorker.java
@@ -1,0 +1,33 @@
+package pro.beam.api.util;
+
+import java.util.Queue;
+import java.util.function.Function;
+
+public abstract class AbstractQueueWorker<T> implements Runnable {
+    protected final Function<T, Boolean> applicant;
+    protected final Queue<T> queue;
+
+    public AbstractQueueWorker(Queue<T> queue, Function<T, Boolean> applicant) {
+        this.queue = queue;
+        this.applicant = applicant;
+    }
+
+    @Override public void run() {
+        T next;
+        while (this.shouldWork()) {
+            if ((next = this.queue.element()) != null) {
+                boolean shouldRemove = this.applicant.apply(next);
+                if (shouldRemove) {
+                    this.notifyWorkOn(next);
+                    this.queue.remove(next);
+                }
+            }
+        }
+    }
+
+    protected abstract boolean shouldWork();
+
+    protected void notifyWorkOn(T element) {
+        // no-op
+    }
+}

--- a/src/main/java/pro/beam/api/util/QueueWorker.java
+++ b/src/main/java/pro/beam/api/util/QueueWorker.java
@@ -3,21 +3,12 @@ package pro.beam.api.util;
 import java.util.Queue;
 import java.util.function.Function;
 
-public class QueueWorker<T> implements Runnable {
-    protected final Function<T, Boolean> applicant;
-    protected final Queue<T> queue;
-
+public class QueueWorker<T> extends AbstractQueueWorker<T> {
     public QueueWorker(Queue<T> queue, Function<T, Boolean> applicant) {
-        this.queue = queue;
-        this.applicant = applicant;
+        super(queue, applicant);
     }
 
-    @Override public void run() {
-        for (;;) {
-            T next = this.queue.poll();
-            if (next != null) {
-                this.applicant.apply(next);
-            }
-        }
+    @Override protected boolean shouldWork() {
+        return true;
     }
 }

--- a/src/main/java/pro/beam/api/util/QueueWorker.java
+++ b/src/main/java/pro/beam/api/util/QueueWorker.java
@@ -1,0 +1,23 @@
+package pro.beam.api.util;
+
+import java.util.Queue;
+import java.util.function.Function;
+
+public class QueueWorker<T> implements Runnable {
+    protected final Function<T, Boolean> applicant;
+    protected final Queue<T> queue;
+
+    public QueueWorker(Queue<T> queue, Function<T, Boolean> applicant) {
+        this.queue = queue;
+        this.applicant = applicant;
+    }
+
+    @Override public void run() {
+        for (;;) {
+            T next = this.queue.poll();
+            if (next != null) {
+                this.applicant.apply(next);
+            }
+        }
+    }
+}

--- a/src/main/java/pro/beam/api/util/SingleDispatchQueueWorker.java
+++ b/src/main/java/pro/beam/api/util/SingleDispatchQueueWorker.java
@@ -1,0 +1,20 @@
+package pro.beam.api.util;
+
+import java.util.Queue;
+import java.util.function.Function;
+
+public class SingleDispatchQueueWorker<T> extends AbstractQueueWorker<T> {
+    private boolean workWasDone = false;
+
+    public SingleDispatchQueueWorker(Queue<T> queue, Function<T, Boolean> applicant) {
+        super(queue, applicant);
+    }
+
+    @Override protected boolean shouldWork() {
+        return !this.workWasDone;
+    }
+
+    @Override public void notifyWorkOn(T element) {
+        this.workWasDone = true;
+    }
+}


### PR DESCRIPTION
This PR introduces a new API for working with `BeamChatConnectable`s.  The responsibilities of the Connectable variant of the `Chat` model don't really belong in the `BeamChat` class, since the `BeamChat` object is really just a representation of the model that is sent down from the server.

My first attempt to solve this problem was to simply `@Override` the `WebSocketClient#onClose` method to force a reconnect, but `WebSocketClient` instances cannot be re-used.

The solution here is to introduce a layer of indirection (which is the `BeamChatBridge` object).  It is responsible for coordinating multiple `BeamChatConnectable` instances such that if the one it maintains fails, it swaps it out for a new one, and ports over all of the event handlers.

Since we have this new layer of indirection, the API has changed a bit, and my example code has been updated:

```java
public class Application {
  public static void main(String[] args) throws ExecutionException, InterruptedException {
    BeamAPI beam = new BeamAPI();

    BeamUser ttaylorr = beam.use(UsersService.class).login("<user>", "<pass>").get();
    BeamChat chat = beam.use(ChatService.class).findOne(ttaylorr.channel.id).get();

    BeamChatBridge bridge = chat.bridge(beam).connect();
    bridge.send(AuthenticateMessage.from(ttaylorr.channel, ttaylorr, chat.authkey));

    bridge.on(IncomingMessageEvent.class, new EventHandler<IncomingMessageEvent>() {
      @Override public void onEvent(IncomingMessageEvent event) {
        System.out.println(event.data.getMessage());
      }
    });

    // Simulate disconnect via delay...
    Thread.sleep(1000);
    bridge.disconnect();
    // The thread will pick this up, reconnect, and send the auth packet again!
  }
}
```

I'm opening this PR so that people who use the bot frequently can provide insight on the implementation, etc.

/cc @pocketpac @GraphicalBear 