### PR TITLE
Handle different 2fa response codes

### DIFF
--- a/src/main/java/pro/beam/api/exceptions/BeamException.java
+++ b/src/main/java/pro/beam/api/exceptions/BeamException.java
@@ -1,0 +1,4 @@
+package pro.beam.api.exceptions;
+
+public class BeamException extends Exception {
+}

--- a/src/main/java/pro/beam/api/exceptions/user/TwoFactorWrongCodeException.java
+++ b/src/main/java/pro/beam/api/exceptions/user/TwoFactorWrongCodeException.java
@@ -1,0 +1,6 @@
+package pro.beam.api.exceptions.user;
+
+import pro.beam.api.exceptions.BeamException;
+
+public class TwoFactorWrongCodeException extends BeamException {
+}

--- a/src/main/java/pro/beam/api/exceptions/user/TwoFactorWrongPasswordException.java
+++ b/src/main/java/pro/beam/api/exceptions/user/TwoFactorWrongPasswordException.java
@@ -1,0 +1,6 @@
+package pro.beam.api.exceptions.user;
+
+import pro.beam.api.exceptions.BeamException;
+
+public class TwoFactorWrongPasswordException extends BeamException {
+}

--- a/src/main/java/pro/beam/api/services/impl/UsersService.java
+++ b/src/main/java/pro/beam/api/services/impl/UsersService.java
@@ -1,8 +1,15 @@
 package pro.beam.api.services.impl;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.CheckedFuture;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.http.client.HttpResponseException;
 import pro.beam.api.BeamAPI;
+import pro.beam.api.exceptions.BeamException;
+import pro.beam.api.exceptions.user.TwoFactorWrongCodeException;
+import pro.beam.api.exceptions.user.TwoFactorWrongPasswordException;
 import pro.beam.api.http.BeamHttpClient;
 import pro.beam.api.resource.BeamUser;
 import pro.beam.api.response.users.UserFollowsResponse;
@@ -12,6 +19,9 @@ import pro.beam.api.services.AbstractHTTPService;
 import java.util.Map;
 
 public class UsersService extends AbstractHTTPService {
+    private static final int TWOFACTOR_WRONG_PASSWORD_RESPONSE = 401;
+    private static final int TWOFACTOR_WRONG_CODE_RESPONSE = 499;
+
     public UsersService(BeamAPI beam) {
         super(beam, "users");
     }
@@ -44,14 +54,36 @@ public class UsersService extends AbstractHTTPService {
      * @param authCode The user's two factor authentication code
      * @return
      */
-    public ListenableFuture<BeamUser> login(String username, String password, String authCode) {
+    public CheckedFuture<BeamUser, BeamException> login(String username, String password, String authCode) {
         if (authCode.length() != 6) {
             throw new IllegalArgumentException("two factor authentication code have to be 6 digits (was " + authCode.length() + ")");
         } else {
-            return this.post("login", BeamUser.class, new ImmutableMap.Builder<String, Object>()
-                    .put("username", username)
-                    .put("password", password)
-                    .put("code", authCode).build());
+            ListenableFuture<BeamUser> result = this.post("login", BeamUser.class, new ImmutableMap.Builder<String, Object>()
+                                                        .put("username", username)
+                                                        .put("password", password)
+                                                        .put("code", authCode).build());
+
+            // Map HTTP response errors into 2FA-relevant errors
+            return Futures.makeChecked(result, new Function<Exception, BeamException>() {
+                @Override public BeamException apply(Exception e) {
+                    Throwable cause = e.getCause();
+                    if (!(cause instanceof HttpResponseException)) {
+                        return null;
+                    }
+
+                    HttpResponseException hre = (HttpResponseException) cause;
+                    int status = hre.getStatusCode();
+
+                    switch (status) {
+                        case TWOFACTOR_WRONG_CODE_RESPONSE:
+                            return new TwoFactorWrongCodeException();
+                        case TWOFACTOR_WRONG_PASSWORD_RESPONSE:
+                            return new TwoFactorWrongPasswordException();
+                        default:
+                            return null;
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
This PR introduces custom exceptions that are thrown when an incorrect 2fa login attempt is made.  Usage guidelines follow below:

```java
package pro.beam.api;

import pro.beam.api.exceptions.BeamException;
import pro.beam.api.exceptions.user.TwoFactorWrongCodeException;
import pro.beam.api.exceptions.user.TwoFactorWrongPasswordException;
import pro.beam.api.services.impl.UsersService;

import java.util.concurrent.ExecutionException;

public class Application {
    public static void main(String[] args) throws ExecutionException, InterruptedException {
        BeamAPI beam = new BeamAPI();

        try {
            beam.use(UsersService.class).login("username", "password", "2facode").checkedGet();
        } catch(TwoFactorWrongCodeException e) {
            // wrong code
        } catch(TwoFactorWrongPasswordException e) {
            // wrong password
        } catch (BeamException e) {
            // something went horribly wrong
        }
    }
}
```