### PR TITLE
Support for new message format + Additional improvements

### DIFF
--- a/src/main/java/pro/beam/api/resource/channel/CachedMessage.java
+++ b/src/main/java/pro/beam/api/resource/channel/CachedMessage.java
@@ -1,25 +1,27 @@
 package pro.beam.api.resource.channel;
 
+import com.google.gson.annotations.SerializedName;
 import pro.beam.api.resource.BeamUser;
 import pro.beam.api.resource.chat.events.data.IncomingMessageData;
+import pro.beam.api.resource.chat.events.data.MessageComponent;
 
 import java.util.List;
 import java.util.UUID;
 
 public class CachedMessage {
-    public IncomingMessageData.MessagePart message;
+    public MessageComponent message;
     public int channel;
     public UUID id;
-    public int user_id;
-    public String user_name;
-    public List<BeamUser.Role> roles;
+    @SerializedName("user_id") public int userId;
+    @SerializedName("user_name") public String userName;
+    @SerializedName("user_roles") public List<BeamUser.Role> userRoles;
 
     public IncomingMessageData getMessage() {
         IncomingMessageData d = new IncomingMessageData();
         d.channel = this.channel;
         d.id = this.id.toString();
-        d.user_id = this.user_id;
-        d.user_name = this.user_name;
+        d.userId = this.userId;
+        d.userName = this.userName;
         d.message = this.message;
 
         return d;

--- a/src/main/java/pro/beam/api/resource/channel/CachedMessage.java
+++ b/src/main/java/pro/beam/api/resource/channel/CachedMessage.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.UUID;
 
 public class CachedMessage {
-    public List<IncomingMessageData.MessagePart> message;
+    public IncomingMessageData.MessagePart message;
     public int channel;
     public UUID id;
     public int user_id;
@@ -18,7 +18,7 @@ public class CachedMessage {
         IncomingMessageData d = new IncomingMessageData();
         d.channel = this.channel;
         d.id = this.id.toString();
-        d.user_id = String.valueOf(this.user_id);
+        d.user_id = this.user_id;
         d.user_name = this.user_name;
         d.message = this.message;
 

--- a/src/main/java/pro/beam/api/resource/chat/events/data/IncomingMessageData.java
+++ b/src/main/java/pro/beam/api/resource/chat/events/data/IncomingMessageData.java
@@ -14,9 +14,9 @@ public class IncomingMessageData extends AbstractChatEvent.EventData {
     public int channel;
     public String id;
     public String user_name;
-    public String user_id;
+    public int user_id;
     public List<BeamUser.Role> user_roles;
-    public List<MessagePart> message;
+    public MessagePart message;
 
     @Deprecated()
     public String getMessage() {
@@ -24,10 +24,9 @@ public class IncomingMessageData extends AbstractChatEvent.EventData {
     }
 
     public String asString() {
-        return Joiner.on("").join(Iterators.transform(this.message.iterator(), new Function<MessagePart, String>() {
-            @Override public String apply(MessagePart part) {
+        return Joiner.on("").join(Iterators.transform(this.message.message.iterator(), new Function<MessagePart.MessageMessagePart, String>() {
+            @Override public String apply(MessagePart.MessageMessagePart part) {
                 switch(part.type) {
-                    case ME:
                     case EMOTICON:
                         return part.text;
                     case LINK:
@@ -41,27 +40,36 @@ public class IncomingMessageData extends AbstractChatEvent.EventData {
     }
 
     public static class MessagePart {
-        public Type type;
-        public String url;
-        public String data;
-        public String path;
-        public String text;
+        public MessageMetaPart meta;
+        public List<MessageMessagePart> message;
 
-        // Emoticon-related
-        public String source;
-        public String pack;
-        public Coords coords;
-
-        public static class Coords {
-            public int x;
-            public int y;
+        public static class MessageMetaPart {
+            public boolean me;
         }
 
-        public static enum Type {
-            @SerializedName("me") ME,
-            @SerializedName("text") TEXT,
-            @SerializedName("emoticon") EMOTICON,
-            @SerializedName("link") LINK,
+        public static class MessageMessagePart {
+            public Type type;
+            public String data;
+            public String text;
+
+            // Emoticon-related
+            public String source;
+            public String pack;
+            public Coords coords;
+
+            // Link-related
+            public String url;
+
+            public static class Coords {
+                public int x;
+                public int y;
+            }
+
+            public enum Type {
+                @SerializedName("text")TEXT,
+                @SerializedName("emoticon")EMOTICON,
+                @SerializedName("link")LINK,
+            }
         }
     }
 }

--- a/src/main/java/pro/beam/api/resource/chat/events/data/IncomingMessageData.java
+++ b/src/main/java/pro/beam/api/resource/chat/events/data/IncomingMessageData.java
@@ -13,10 +13,10 @@ import com.google.gson.annotations.SerializedName;
 public class IncomingMessageData extends AbstractChatEvent.EventData {
     public int channel;
     public String id;
-    public String user_name;
-    public int user_id;
-    public List<BeamUser.Role> user_roles;
-    public MessagePart message;
+    @SerializedName("user_name") public String userName;
+    @SerializedName("user_id") public int userId;
+    @SerializedName("user_roles") public List<BeamUser.Role> userRoles;
+    public MessageComponent message;
 
     @Deprecated()
     public String getMessage() {
@@ -24,8 +24,8 @@ public class IncomingMessageData extends AbstractChatEvent.EventData {
     }
 
     public String asString() {
-        return Joiner.on("").join(Iterators.transform(this.message.message.iterator(), new Function<MessagePart.MessageMessagePart, String>() {
-            @Override public String apply(MessagePart.MessageMessagePart part) {
+        return Joiner.on("").join(Iterators.transform(this.message.message.iterator(), new Function<MessageComponent.MessageTextComponent, String>() {
+            @Override public String apply(MessageComponent.MessageTextComponent part) {
                 switch(part.type) {
                     case EMOTICON:
                         return part.text;
@@ -37,39 +37,5 @@ public class IncomingMessageData extends AbstractChatEvent.EventData {
                 }
             }
         }));
-    }
-
-    public static class MessagePart {
-        public MessageMetaPart meta;
-        public List<MessageMessagePart> message;
-
-        public static class MessageMetaPart {
-            public boolean me;
-        }
-
-        public static class MessageMessagePart {
-            public Type type;
-            public String data;
-            public String text;
-
-            // Emoticon-related
-            public String source;
-            public String pack;
-            public Coords coords;
-
-            // Link-related
-            public String url;
-
-            public static class Coords {
-                public int x;
-                public int y;
-            }
-
-            public enum Type {
-                @SerializedName("text")TEXT,
-                @SerializedName("emoticon")EMOTICON,
-                @SerializedName("link")LINK,
-            }
-        }
     }
 }

--- a/src/main/java/pro/beam/api/resource/chat/events/data/IncomingWidgetData.java
+++ b/src/main/java/pro/beam/api/resource/chat/events/data/IncomingWidgetData.java
@@ -2,15 +2,16 @@ package pro.beam.api.resource.chat.events.data;
 
 import java.util.List;
 
+import com.google.gson.annotations.SerializedName;
 import pro.beam.api.resource.BeamUser;
 import pro.beam.api.resource.chat.AbstractChatEvent;
 
 public class IncomingWidgetData extends AbstractChatEvent.EventData {
     public int channel;
     public String id;
-    public String user_name;
-    public int user_id;
-    public List<BeamUser.Role> user_roles;
+    @SerializedName("user_name") public String userName;
+    @SerializedName("user_id") public int userId;
+    @SerializedName("user_roles") public List<BeamUser.Role> userRoles;
     public String message;
 
     public String getMessage() {

--- a/src/main/java/pro/beam/api/resource/chat/events/data/IncomingWidgetData.java
+++ b/src/main/java/pro/beam/api/resource/chat/events/data/IncomingWidgetData.java
@@ -9,7 +9,7 @@ public class IncomingWidgetData extends AbstractChatEvent.EventData {
     public int channel;
     public String id;
     public String user_name;
-    public String user_id;
+    public int user_id;
     public List<BeamUser.Role> user_roles;
     public String message;
 

--- a/src/main/java/pro/beam/api/resource/chat/events/data/MessageComponent.java
+++ b/src/main/java/pro/beam/api/resource/chat/events/data/MessageComponent.java
@@ -1,0 +1,40 @@
+package pro.beam.api.resource.chat.events.data;
+
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class MessageComponent {
+    public MessageMeta meta;
+    public List<MessageTextComponent> message;
+
+    public static class MessageMeta {
+        public boolean me;
+    }
+
+    public static class MessageTextComponent {
+        public Type type;
+        public String data;
+        public String text;
+
+        // Emoticon-related
+        public String source;
+        public String pack;
+        public Coords coords;
+
+        // Link-related
+        public String url;
+
+        public static class Coords {
+            public int x;
+            public int y;
+        }
+
+        public enum Type {
+            @SerializedName("text")TEXT,
+            @SerializedName("emoticon")EMOTICON,
+            @SerializedName("link")LINK,
+        }
+    }
+}

--- a/src/main/java/pro/beam/api/services/impl/ChannelsService.java
+++ b/src/main/java/pro/beam/api/services/impl/ChannelsService.java
@@ -41,8 +41,13 @@ public class ChannelsService extends AbstractHTTPService {
         return this.get("", ShowChannelsResponse.class, options.build());
     }
 
+    @Deprecated
     public ListenableFuture<BeamChannel> findOne(String id) {
         return this.get(id, BeamChannel.class);
+    }
+
+    public ListenableFuture<BeamChannel> findOne(int id) {
+        return this.get(String.valueOf(id), BeamChannel.class);
     }
 
     public ListenableFuture<?> follow(BeamChannel channel, BeamUser follower) {


### PR DESCRIPTION
- Fix for new message format
- Add findOne that takes a int id instead of string and deprecated the string version, since int makes more sense
- Changed int values to be actual int values
- Changed fields from underscore seperator to camelCase
- Fixed missing roles on CachedMessage
- Moved MessageComponent (previously MessagePart) out of IncomingMessageData